### PR TITLE
Avoid crashing on large screenshot using blob URL

### DIFF
--- a/screenshotter.DOM.js
+++ b/screenshotter.DOM.js
@@ -1,5 +1,24 @@
 (function() {
-  
+  function dataToBlobURL(dataURL) {
+    var parts = dataURL.match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
+
+    //assume base64 encoding
+    var binStr = atob(parts[3]);
+
+    //convert to binary in ArrayBuffer
+    var buf = new ArrayBuffer(binStr.length);
+    var view = new Uint8Array(buf);
+    for(var i = 0; i < view.length; i++)
+      view[i] = binStr.charCodeAt(i);
+
+
+    var builder = new WebKitBlobBuilder();
+    builder.append(buf);
+
+    //create blob with mime type, create URL for it
+    var URL = webkitURL.createObjectURL(builder.getBlob(parts[1]))
+    return URL;
+  }
   var shared = {};
   
   // 1
@@ -45,7 +64,8 @@
     var div = window.document.createElement('div');
     div.id = "blipshot";
     div.innerHTML = '<div id="dim" style="position: absolute !important; height: ' + window.document.body.scrollHeight + 'px !important; width: 100% !important; top: 0px !important; left: 0px !important; background: #000000 !important; opacity: 0.66 !important; z-index: 666666 !important;"> </div>';
-    div.innerHTML += '<p style="-webkit-box-shadow: 0px 5px 10px #000000; margin: 20px; background: #ffffff; position: absolute; top: 0; right: 0; z-index: 666667 !important;"><img alt="' + filename + '" src="' +  shared.imageDataURL + '" width= "400" /></p>';
+    var blobURL = dataToBlobURL(shared.imageDataURL);
+    div.innerHTML += '<p style="-webkit-box-shadow: 0px 5px 10px #000000; margin: 20px; background: #ffffff; position: absolute; top: 0; right: 0; z-index: 666667 !important;"><img alt="' + filename + '" src="' +  blobURL + '" width= "400" /></p>';
     window.document.body.appendChild(div);
     
     function removeDiv() {


### PR DESCRIPTION
I've been participating in the discussion over at [Chrome issue 69227](http://code.google.com/p/chromium/issues/detail?id=69227) and I was curious to try using blobURLs in an actual application.  Lacking one myself, I found yours. :)

I tested taking a screenshot of the [WHATWG living Canvas standard](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html) on Chrome 17.0.963.46 on OS X 10.7.2.  Prior to this change, a 1422 x 36724 pixel screenshot of crashed on drag and drop; post-change, the drag and drop succeeded, making a 9.3MB png.
